### PR TITLE
 Replaced partial functions and error calls with Either String monad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+.stack-work/

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Now let's look at some complete examples.
 import Haquery
 
 example :: Tag
-example = html [
+example = html [] [
         head' [] [],
         body [] [
             div' [at "id" "main", at "class" "c1"] [
@@ -117,7 +117,7 @@ Let's do a selection.
 
 ```haskell
 > select "#main" example
-[<div id="main" class="c1">
+Right [<div id="main" class="c1">
     <div id="sub1"></div>
     <div id="sub2"></div>
 </div>]
@@ -129,7 +129,7 @@ If we want to modify tags matching a selector, we can use the alter function.
 
 ```haskell
 > :t alter
-alter :: T.Text -> Tag -> (Tag -> Tag) -> Tag
+alter :: T.Text -> (Tag -> Tag) -> Tag -> Either String Tag
 ```
 
 As we can see, the alter functions needs a selector, a tag to search in, and a function which transforms
@@ -141,8 +141,8 @@ addClass :: T.Text -> Tag -> Tag
 ```
 
 ```haskell
-> alter "div" example (addClass "hello-class")
-<html>
+> alter "div" (addClass "hello-class") example
+Right <html>
     <head></head>
     <body>
         <div id="main" class="c1 hello-class">
@@ -156,5 +156,5 @@ addClass :: T.Text -> Tag -> Tag
 For parsing HTML into `Tag`s, use `parseHtml`:
 
 ```haskell
-parseHtml :: T.Text -> [Tag]
+parseHtml :: T.Text -> Either String [Tag]
 ```

--- a/haquery.cabal
+++ b/haquery.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                haquery
-version:             0.1.1.3
+version:             1.0.0.0
 synopsis:            jQuery for Haskell.
 -- description:         
 homepage:            https://github.com/crufter/haquery
@@ -18,13 +18,14 @@ cabal-version:       >=1.8
 library
   exposed-modules:     Haquery
   -- other-modules:       
-  build-depends:       base >= 4.5 && < 4.10,
+  build-depends:       base,
                        transformers,
                        split,
                        containers,
                        text,
                        parsec,
-                       tagsoup
+                       tagsoup,
+                       monad-loops
   hs-source-dirs:      src
 
 Test-Suite test-haquery

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-7.3
+resolver: lts-10.2
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/tests/HaquerySpec.hs
+++ b/tests/HaquerySpec.hs
@@ -2,9 +2,9 @@
 
 module HaquerySpec (main, spec) where
 
-import Haquery
-import Test.Hspec
-import qualified Data.Text as T
+import qualified Data.Text  as T
+import           Haquery
+import           Test.Hspec
 
 cases1 :: [(Tag, T.Text, Bool)]
 cases1 = [
@@ -216,14 +216,14 @@ spec = do
 
 testMatches :: (Tag, T.Text, Bool) -> Expectation
 testMatches (tag, selector, shouldMatch) =
-  matches selector tag `shouldBe` shouldMatch
+  matches selector tag `shouldBe` Right shouldMatch
 
 testParseHtml :: Tag -> Expectation
 testParseHtml tag =
   -- TODO: use QuickCheck
-  parseHtml (render tag) `shouldBe` [tag]
+  parseHtml (render tag) `shouldBe` Right [tag]
 
 testSelect :: (Tag, [(T.Text, Int)]) -> Expectation
 testSelect (tag, selects) = mapM_ f selects
   where
-    f (selector, numMatches) = length (select selector tag) `shouldBe` numMatches
+    f (selector, numMatches) = length <$> (select selector tag) `shouldBe` Right numMatches


### PR DESCRIPTION
* Changed the signature of `parseHtml` and `match'` functions to return `Either String` monad by replacing the calls to `error` with `Left`.
* Updated README and tests